### PR TITLE
rename app builder

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,20 +63,20 @@ config:
 ### Example
 To enable the S3 Fetcher, deploy the chart with the above configuration.
 
-## Ingress Finder
+## homepage service file builder
 
-The Ingress Finder is a sidecar container that scans for ingress URLs and appends them to sections of the [`services.yaml`](https://gethomepage.dev/widgets/) file. This is useful for dynamically updating the application with ingress information.
+The app entry builder is a sidecar container that scans for Kubernetes resource URLs and appends them to sections of the [`services.yaml`](https://gethomepage.dev/widgets/) file. This is useful for dynamically updating the application with deployed app information.
 
 ### Configuration
 Add the following configuration to your `values.yaml` file:
 ```yaml
 config:
-  ingressFinder:
+  appEntryBuilder:
     enabled: true
     sleepIntervalSecs: 60
 ```
 
 ### Example
-To enable the Ingress Finder, deploy the chart with the above configuration.
+To enable the app entry builder, deploy the chart with the above configuration.
 
-> **Note**: The Ingress Finder is currently a [private image and repo](https://github.com/aidan-Wallace/homepage-extensions/), but plans are in place to release it soon.
+> **Note**: The app entry builder is currently a [private image and repo](https://github.com/aidan-Wallace/homepage-extensions/), but plans are in place to release it soon.

--- a/charts/homepage/Chart.yaml
+++ b/charts/homepage/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.2
+version: 0.2.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/homepage/templates/_helpers.tpl
+++ b/charts/homepage/templates/_helpers.tpl
@@ -6,14 +6,14 @@ Expand the name of the chart.
 {{- end }}
 
 {{/*
-Create the name of the ingress finder container.
+Create the name of the Homepage app builder container.
 */}}
-{{- define "homepage.ingressFinderName" -}}
-{{ .Chart.Name }}-ingress-finder
+{{- define "homepage.appBuilder" -}}
+{{ .Chart.Name }}-app-entry-builder
 {{- end }}
 
 {{/*
-Create the name of the ingress finder container.
+Create the name of the S3 data fetcher container.
 */}}
 {{- define "homepage.s3FetcherName" -}}
 {{ .Chart.Name }}-s3-fetcher

--- a/charts/homepage/templates/deployment.yaml
+++ b/charts/homepage/templates/deployment.yaml
@@ -102,15 +102,15 @@ spec:
           env:
             - name: HOMEPAGE_ALLOWED_HOSTS
               value: {{ .Values.config.allowedHosts }}
-        {{- if .Values.config.ingressFinder.enabled }}
-        - name: {{ include "homepage.ingressFinderName" . }}
+        {{- if .Values.config.appEntryBuilder.enabled }}
+        - name: {{ include "homepage.appBuilder" . }}
           {{- with .Values.securityContext }}
           securityContext:
             {{- toYaml . | nindent 12 }}
           {{- end }}
-          image: "{{ .Values.config.ingressFinder.image.repository }}:{{ .Values.config.ingressFinder.image.tag | default .Chart.AppVersion }}"
-          imagePullPolicy: {{ .Values.config.ingressFinder.image.pullPolicy }}
-          {{- with .Values.config.ingressFinder.resources }}
+          image: "{{ .Values.config.appEntryBuilder.image.repository }}:{{ .Values.config.appEntryBuilder.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.config.appEntryBuilder.image.pullPolicy }}
+          {{- with .Values.config.appEntryBuilder.resources }}
           resources:
             {{- toYaml . | nindent 12 }}
           {{- end }}
@@ -120,12 +120,12 @@ spec:
           {{- end }}
           env:
             - name: SleepIntervalSecs
-              value: {{ .Values.config.ingressFinder.sleepIntervalSecs | default "60" | quote }}
+              value: {{ .Values.config.appEntryBuilder.sleepIntervalSecs | default "60" | quote }}
             - name: ServicesFilepath
               # TODO: Dynamically set dir based on volumeMounts
               value: "/app/config/services.yaml"
             - name: Serilog__MinimumLevel__Default
-              value: {{ .Values.config.ingressFinder.logLevel | default "Information" | quote }}
+              value: {{ .Values.config.appEntryBuilder.logLevel | default "Information" | quote }}
         {{- end }}
       {{- with .Values.volumes }}
       volumes:

--- a/charts/homepage/values.yaml
+++ b/charts/homepage/values.yaml
@@ -31,7 +31,7 @@ serviceAccount:
   # If not set and create is true, a name is generated using the fullname template
   name: ""
 
-  # Configuration for creating a ClusterRoleBinding. This is required by the ingressFiner container
+  # Configuration for creating a ClusterRoleBinding. This is required by the app builder container
   clusterRoleBinding:
     create: true
     roleName: "cluster-admin"
@@ -128,9 +128,9 @@ config:
   # More information can be found here: https://github.com/gethomepage/homepage/blob/dev/docs/installation/index.md#homepage_allowed_hosts
   allowedHosts: "example.local"
 
-  # a sidecar container that will automatically scan ingress annotations and automatically append the ingress
+  # a sidecar container that will automatically build app entries for Homepage based off Kubernetes resources.
   # url to the homepage app.
-  ingressFinder:
+  appEntryBuilder:
     enabled: false
 
     # Time to sleep between loop iterations

--- a/examples/helmfile/helmfile.yaml
+++ b/examples/helmfile/helmfile.yaml
@@ -15,5 +15,5 @@ releases:
                   pathType: ImplementationSpecific
 
         config:
-          ingressFinder:
+          appEntryBuilder:
             enabled: true


### PR DESCRIPTION
The Homepage annotation processor no longer just processes ingresses. It now includes services and could have more later.

- **Rename app builder**
- **bump chart version**
